### PR TITLE
Update documentation configuration and copyright year in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
-import importlib.metadata
+import sys
+from pathlib import Path
+
+# Add the src directory to the path to import the version directly from source
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from curvelets._version import version as _version
 
 project = "Curvelets"
-copyright = "2024, Carlos Alberto da Costa Filho"
+copyright = "2026, Carlos Alberto da Costa Filho"
 author = "Carlos Alberto da Costa Filho"
-version = release = importlib.metadata.version("curvelets")
+version = release = _version
 
 extensions = [
     "myst_parser",


### PR DESCRIPTION
- Added the src directory to the Python path for direct version import.
- Updated copyright year from 2024 to 2026.
- Replaced the version retrieval method to import directly from the source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Sphinx config to read the package version from source instead of metadata.
> 
> - Add `src` to `sys.path` and import `version` from `curvelets._version`
> - Replace `importlib.metadata.version("curvelets")` with `version = release = _version`
> - Update copyright year to `2026`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecf5c72b277ff3939e9bcb5ba39f948d5d21849a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->