### PR TITLE
Remove conda badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@
 <!-- prettier-ignore-start -->
 [actions-badge]:            https://github.com/cako/curvelets/workflows/CI/badge.svg
 [actions-link]:             https://github.com/cako/curvelets/actions
-[conda-badge]:              https://img.shields.io/conda/vn/conda-forge/Curvelets
-[conda-link]:               https://github.com/conda-forge/Curvelets-feedstock
 [github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
 [github-discussions-link]:  https://github.com/cako/curvelets/discussions
 [pypi-link]:                https://pypi.org/project/Curvelets/


### PR DESCRIPTION
Removed conda badge and link from README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes conda-related badge/link references from `README.md`.
> 
> - Deletes the `[conda-badge]` and `[conda-link]` reference definitions in the SPHINX block
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d809e0926e54d091baedaad06389e136e33d6c65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->