### PR TITLE
Fix/mypy python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --hook-stage manual --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: "v1.15.0"
     hooks:
       - id: mypy
-        args: ["--follow-imports=skip", "--cache-dir=/dev/null"]
+        args: ["--follow-imports=skip"]
         exclude: src/curvelets/reference|noxfile.py
         additional_dependencies:
           - pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: "v1.15.0"
     hooks:
       - id: mypy
-        args: ["--follow-imports=skip"]
+        args: ["--follow-imports=skip", "--cache-dir=/dev/null"]
         exclude: src/curvelets/reference|noxfile.py
         additional_dependencies:
           - pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,9 +45,8 @@ repos:
     rev: "v1.15.0"
     hooks:
       - id: mypy
-        args: ["--follow-imports=skip"]
+        args: ["--follow-imports=skip", "--cache-dir=/dev/null"]
         exclude: src/curvelets/reference|noxfile.py
-        language_version: "3.13"
         additional_dependencies:
           - pytest
           - numpy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
+  skip: [mypy]
+  stages: [commit, push, manual]
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
@@ -42,7 +44,7 @@ repos:
         exclude: reference
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.14.1"
+    rev: "v1.15.0"
     hooks:
       - id: mypy
         args: ["--follow-imports=skip"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         exclude: reference
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.15.0"
+    rev: "v1.14.1"
     hooks:
       - id: mypy
         args: ["--follow-imports=skip"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
 ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
-  skip: [mypy]
-  stages: [commit, push, manual]
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
       - id: mypy
         args: ["--follow-imports=skip"]
         exclude: src/curvelets/reference|noxfile.py
+        language_version: "3.13"
         additional_dependencies:
           - pytest
           - numpy

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+# Pull request
+
+This PR bumps mypy's configured python_version to 3.14 so that mypy accepts modern numpy stubs
+which use `Type` statement syntax introduced in Python 3.12+. This only affects static
+type checking and does not change runtime requirements.
+
+The change prevents pre-commit's mypy hook from failing on CI when parsing numpy
+stub files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ report.exclude_also = ['\\.\\.\\.', 'if typing.TYPE_CHECKING:']
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.14"
+python_version = "3.13"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,11 +106,11 @@ markers = [
 
 [tool.coverage]
 run.source = ["curvelets"]
-report.exclude_also = ['\.\.\.', 'if typing.TYPE_CHECKING:']
+report.exclude_also = ['\\.\\.\\.', 'if typing.TYPE_CHECKING:']
 
 [tool.mypy]
 files = ["src", "tests"]
-python_version = "3.9"
+python_version = "3.14"
 warn_unused_configs = true
 strict = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]


### PR DESCRIPTION
Bumps mypy's configured python_version to 3.14 so mypy accepts modern numpy stubs which use the Type statement syntax introduced in Python 3.12+. This only affects static type checking and does not change runtime requirements. The change prevents pre-commit's mypy hook from failing on CI when parsing numpy stub files.