### PR TITLE
Fix Sphinx build cross-reference and deprecation warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from curvelets._version import version as _version
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*set_application.*is deprecated.*",
+    category=DeprecationWarning,
+)
 
 project = "Curvelets"
 copyright = "2026, Carlos Alberto da Costa Filho"
@@ -65,6 +72,10 @@ nitpick_ignore = [
     ("py:obj", "curvelets.numpy.MUDCTCoefficients"),
     ("py:class", "UDCTCoefficients"),
     ("py:obj", "UDCTCoefficients"),
+    ("py:class", "_T"),
+    ("py:class", "_F"),
+    ("py:class", "curvelets.numpy.typing._T"),
+    ("py:class", "curvelets.numpy.typing._F"),
     ("py:class", '{"real"'),
     ("py:class", '"complex"'),
     ("py:class", '"monogenic"}'),
@@ -139,4 +150,4 @@ def setup(app):
 bibtex_bibfiles = ["references.bib"]
 bibtex_reference_style = "author_year"
 # bibtex_default_style = "plain"
-suppress_warnings = ["bibtex.duplicate_citation", "config.cache"]
+suppress_warnings = ["bibtex.duplicate_citation", "config.cache", "ref.python"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,8 +7,9 @@ from pathlib import Path
 # Add the src directory to the path to import the version directly from source
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from curvelets._version import version as _version
 import warnings
+
+from curvelets._version import version as _version
 
 warnings.filterwarnings(
     "ignore",


### PR DESCRIPTION
### Summary
Resolves Sphinx documentation build warnings across both Python 3.11 (used on ReadTheDocs) and Python 3.12 (`nox -s docs`).

### Changes
- **Filtered `set_application` deprecation warning**: Suppressed `RemovedInSphinx10Warning` emitted when `sphinx_autodoc_typehints` calls `parser.set_application()` under Sphinx 8.x.
- **Ignored internal `TypeVar` references**: Added `_T` / `_F` (and `curvelets.numpy.typing._T` / `_F`) to `nitpick_ignore` to resolve missing class reference targets (`ref.class`) when documenting `TypeAliasType` under Python 3.11.
- **Suppressed redundant cross-reference warnings**: Added `"ref.python"` to `suppress_warnings` to eliminate multiple target cross-reference warnings (`more than one target found for cross-reference 'UDCTCoefficients'`) caused by multiple re-exports and module definitions across `curvelets.numpy` and `curvelets.torch`.

### Verification
- Ran full, fresh-environment (`-E`) Sphinx builds across both **Python 3.11** and **Python 3.12**.
- Confirmed that both builds succeed cleanly with `0 warnings`.